### PR TITLE
Adds single flight capability

### DIFF
--- a/example/example.toml
+++ b/example/example.toml
@@ -29,11 +29,13 @@ files = [
     #    "rnd_inv_2120.nc",
 ]
 # base emission inventories, only considered if rel_to_base = true
-rel_to_base = true
+rel_to_base = false
 base.dir = "input/"
 base.files = [
-    "emi_inv_2020.nc",
-    "emi_inv_2050.nc",
+    "rnd_inv_2020.nc",
+    "rnd_inv_2030.nc",
+    "rnd_inv_2040.nc",
+    "rnd_inv_2050.nc",
 ]
 
 # Output options
@@ -51,7 +53,7 @@ concentrations = false
 [time]
 dir = "../repository/"
 # Time range in years: t_start, t_end, step, (t_end not included)
-range = [2020, 2061, 1]
+range = [2020, 2051, 1]
 # Time evolution of emissions
 # either type "scaling" or type "norm"
 #file = "time_scaling_example.nc"

--- a/example/example.toml
+++ b/example/example.toml
@@ -28,6 +28,13 @@ files = [
     #    "rnd_inv_2110.nc",
     #    "rnd_inv_2120.nc",
 ]
+# base emission inventories, only considered if rel_to_base = true
+rel_to_base = true
+base.dir = "input/"
+base.files = [
+    "emi_inv_2020.nc",
+    "emi_inv_2050.nc",
+]
 
 # Output options
 [output]
@@ -44,13 +51,13 @@ concentrations = false
 [time]
 dir = "../repository/"
 # Time range in years: t_start, t_end, step, (t_end not included)
-range = [2020, 2051, 1]
+range = [2020, 2061, 1]
 # Time evolution of emissions
 # either type "scaling" or type "norm"
 #file = "time_scaling_example.nc"
 #file = "time_norm_example.nc"
 
-# Background concentrations
+# Global background concentrations
 [background]
 dir = "../repository/"
 CO2.file = "co2_bg.nc"
@@ -104,3 +111,7 @@ cont.efficacy = 0.59
 types = ["AGWP", "ATR", "AGTP"] # valid climate metrics: AGTP, AGWP, ATR
 H = [31]                        # Time horizon, t_final = t_0 + H - 1
 t_0 = [2020]                    # Start time for metrics calculation
+
+# aircraft defined in inventory
+[aircraft]
+types = ["KER", "SAF", "LH2"]

--- a/openairclim/calc_cont.py
+++ b/openairclim/calc_cont.py
@@ -36,6 +36,38 @@ cc_plev_vals = np.array([
 ])
 
 
+def check_cont_input(ds_cont, inv_dict, base_inv_dict):
+    """Checks the input data for the contrail module.
+
+    Args:
+        config (dict): Configuration dictionary from config file.
+        ds_cont (xr.Dataset): Dataset of precalculated contrail data.
+        inv_dict (dict): Dictionary of emission inventory xarrays,
+            keys are inventory years.
+        base_inv_dict (dict): Dictionary of base emission inventory
+            xarrays, keys are inventory years.
+    """
+
+    # check resp_cont
+    required_vars = ["ISS", "SAC_CON", "SAC_LH2"]
+    required_coords = ["lat", "lon", "plev"]
+    required_units = ["degrees_north", "degrees_east", "hPa"]
+    for var in required_vars:
+        assert var in ds_cont, f"Missing required variable '{var}' in " \
+            "resp_cont.nc."
+    for coord, unit in zip(required_coords, required_units):
+        assert coord in ds_cont, f"Missing required coordinate '{coord}' in " \
+            "resp_cont.nc."
+        got_unit = ds_cont[coord].attrs.get("units")
+        assert got_unit == unit, f"Incorrect unit for coordinate '{coord}'. " \
+            f"Got '{got_unit}', should be '{unit}'."
+
+    # check years of inventories
+    if base_inv_dict:
+        assert set(inv_dict.keys()).issubset(base_inv_dict.keys()), "inv_dict"\
+        " keys (years) are not a subset of base_inv_dict years (keys)."
+
+
 def calc_cont_grid_areas(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
     """Calculate the cell area of the contrail grid using a simplified method.
     

--- a/openairclim/main.py
+++ b/openairclim/main.py
@@ -189,6 +189,16 @@ def run(file_name):
             ds_cont = oac.open_netcdf_from_config(
                 config, "responses", ["cont"], "resp"
             )["cont"]
+
+            # load base inventories if rel_to_base is TRUE
+            if config["inventories"]["rel_to_base"]:
+                base_inv_dict = oac.open_inventories(config, base=True)
+            else:
+                base_inv_dict = {}
+
+            # check contrail input
+            oac.check_cont_input(ds_cont, inv_dict, base_inv_dict)
+
             # Calculate Contrail Flight Distance Density (CFDD)
             cfdd_dict = oac.calc_cfdd(
                 config, inv_dict, ds_cont
@@ -198,10 +208,8 @@ def run(file_name):
                 config, cfdd_dict, ds_cont
             )
 
-            # if the results compared base inventory are required
+            # if the input inventory is to be compared to the base inventory
             if config["inventories"]["rel_to_base"]:
-                # load base inventories
-                base_inv_dict = oac.open_inventories(config, base=True)
 
                 # calculate base CFDD
                 base_cfdd_dict = oac.calc_cfdd(

--- a/openairclim/main.py
+++ b/openairclim/main.py
@@ -189,15 +189,44 @@ def run(file_name):
             ds_cont = oac.open_netcdf_from_config(
                 config, "responses", ["cont"], "resp"
             )["cont"]
-
             # Calculate Contrail Flight Distance Density (CFDD)
-            cfdd_dict = oac.calc_cfdd(config, inv_dict, ds_cont)
-
+            cfdd_dict = oac.calc_cfdd(
+                config, inv_dict, ds_cont
+            )
             # Calculate contrail cirrus coverage (cccov)
-            cccov_dict = oac.calc_cccov(config, cfdd_dict, ds_cont)
+            cccov_dict = oac.calc_cccov(
+                config, cfdd_dict, ds_cont
+            )
 
-            # Calculate global, area-weighted cccov
-            cccov_tot_dict = oac.calc_cccov_tot(config, cccov_dict)
+            # if the results compared base inventory are required
+            if config["inventories"]["rel_to_base"]:
+                # load base inventories
+                base_inv_dict = oac.open_inventories(config, base=True)
+
+                # calculate base CFDD
+                base_cfdd_dict = oac.calc_cfdd(
+                    config, base_inv_dict, ds_cont
+                )
+                # combine CFDD values of inventory and base
+                comb_cfdd_dict = oac.add_inv_to_base(
+                    cfdd_dict, base_cfdd_dict
+                )
+                # calculate combined cccov
+                comb_cccov_dict = oac.calc_cccov(
+                    config, comb_cfdd_dict, ds_cont
+                )
+                # weight cccov by the difference in CFDD values
+                weighted_cccov_dict = oac.calc_weighted_cccov(
+                    comb_cccov_dict, cfdd_dict, comb_cfdd_dict
+                )
+                # Calculate global, area-weighted cccov
+                cccov_tot_dict = oac.calc_cccov_tot(
+                    config, weighted_cccov_dict
+                )
+
+            else:
+                # Calculate global, area-weighted cccov
+                cccov_tot_dict = oac.calc_cccov_tot(config, cccov_dict)
 
             # Calculate contrail RF
             rf_cont_dict = oac.calc_cont_rf(config, cccov_tot_dict, inv_dict)

--- a/openairclim/read_config.py
+++ b/openairclim/read_config.py
@@ -107,7 +107,24 @@ def check_config(config):
                 raise KeyError("No response file defined for", spec)
         # Check if files exist
         # TODO check evolution file
+
+        # check base inventories (if rel_to_base is TRUE)
         emi_inv_files = []
+        if "rel_to_base" in config["inventories"]:
+            if config["inventories"]["rel_to_base"]:
+                if "dir" in config["inventories"]["base"]:
+                    inv_dir = config["inventories"]["base"]["dir"]
+                else:
+                    inv_dir = ""
+                files_arr = config["inventories"]["base"]["files"]
+                for inv_file in files_arr:
+                    emi_inv_files.append(inv_dir + inv_file)
+        else:
+            msg = "Parameter `rel_to_base` not defined."
+            logging.error(msg)
+            flag = False
+
+        # check inventories
         if "dir" in config["inventories"]:
             inv_dir = config["inventories"]["dir"]
         else:

--- a/openairclim/read_netcdf.py
+++ b/openairclim/read_netcdf.py
@@ -35,12 +35,13 @@ def open_netcdf(netcdf):
     return xr_dict
 
 
-def open_inventories(config):
+def open_inventories(config, base=False):
     """Open inventories from config, check attribute sections
     and time constraints
 
     Args:
         config (dict): Configuration dictionary from config
+        base (bool): If TRUE, loads base inventory, else input inventory
 
     Raises:
         IndexError: if no inv_year is within time_range,
@@ -55,13 +56,27 @@ def open_inventories(config):
     Returns:
         dict: Dictionary of xarray Datasets, keys are years of input inventories
     """
-    # Get list of file names of inventories
+
+    # initialise array of inventories
     inv_arr = []
-    if "dir" in config["inventories"]:
-        inv_dir = config["inventories"]["dir"]
+
+    # if base is TRUE, base inventories are loaded
+    if base:
+        if "dir" in config["inventories"]["base"]:
+            inv_dir = config["inventories"]["base"]["dir"]
+        else:
+            inv_dir = ""
+        files_arr = config["inventories"]["base"]["files"]
+
+    # otherwise, load input inventories
     else:
-        inv_dir = ""
-    files_arr = config["inventories"]["files"]
+        if "dir" in config["inventories"]:
+            inv_dir = config["inventories"]["dir"]
+        else:
+            inv_dir = ""
+        files_arr = config["inventories"]["files"]
+
+    # load files
     for inv_file in files_arr:
         inv_arr.append(inv_dir + inv_file)
     time_config = config["time"]["range"]

--- a/tests/calc_cont_test.py
+++ b/tests/calc_cont_test.py
@@ -223,7 +223,9 @@ class TestCalcWeightedCccov:
 
     def test_empty_inputs(self):
         """Tests empty input dictionaries."""
-        comb_cccov_dict = {}; cfdd_dict = {}; comb_cfdd_dict = {}
+        comb_cccov_dict = {}
+        cfdd_dict = {}
+        comb_cfdd_dict = {}
         result = oac.calc_weighted_cccov(comb_cccov_dict,
                                          cfdd_dict,
                                          comb_cfdd_dict)

--- a/tests/calc_cont_test.py
+++ b/tests/calc_cont_test.py
@@ -209,6 +209,27 @@ class TestCalcCccov:
             "empty cfdd_dict."
 
 
+class TestCalcWeightedCccov:
+    """Tests function calc_weighted_cccov(comb_cccov_dict, cfdd_dict,
+    comb_cfdd_dict)"""
+
+    def test_key_mismatch(self):
+        """Tests mismatched keys in dictionaries."""
+        comb_cccov_dict = {2020: np.array([1.0, 2.0])}
+        cfdd_dict = {2050: np.array([1.0, 2.0])}
+        comb_cfdd_dict = {2020: np.array([1.0, 2.0])}
+        with pytest.raises(AssertionError):
+            oac.calc_weighted_cccov(comb_cccov_dict, cfdd_dict, comb_cfdd_dict)
+
+    def test_empty_inputs(self):
+        """Tests empty input dictionaries."""
+        comb_cccov_dict = {}; cfdd_dict = {}; comb_cfdd_dict = {}
+        result = oac.calc_weighted_cccov(comb_cccov_dict,
+                                         cfdd_dict,
+                                         comb_cfdd_dict)
+        assert not result, "Expected empty result for empty input dictionaries."
+
+
 class TestCalcCccovTot:
     """Tests function calc_cccov_tot(config, cccov_dict)"""
 
@@ -314,4 +335,29 @@ class TestCalcContRF:
                   "time": {"range": [2020, 2051, 1]}}
         with pytest.raises(AssertionError):
             oac.calc_cont_rf(config, {}, {})
-        
+
+
+class TestAddInvToBase:
+    """Tests function add_inv_to_base(inv_dict, base_inv_dict)"""
+
+    def test_key_mismatch(self):
+        """Tests mismatched keys in input dictionaries."""
+        inv_dict = {2020: np.array([1.0, 2.0])}
+        base_inv_dict = {2050: np.array([1.0, 2.0])}
+        with pytest.raises(AssertionError):
+            oac.add_inv_to_base(inv_dict, base_inv_dict)
+
+    def test_addition(self):
+        """Tests function with simple inputs."""
+        inv_dict = {2020: np.array([1.0, 2.0])}
+        base_inv_dict = {2020: np.array([2.0, 3.0])}
+        expected = {2020: np.array([3.0, 5.0])}
+        result = oac.add_inv_to_base(inv_dict, base_inv_dict)
+        np.testing.assert_array_equal(result[2020], expected[2020],
+                                      err_msg="Addition fails for simple input.")
+
+    def test_empty_inputs(self):
+        """Tests empty input dictionaries."""
+        inv_dict = {}; base_inv_dict = {}
+        result = oac.add_inv_to_base(inv_dict, base_inv_dict)
+        assert not result, "Expected empty result for empty input dictionaries."

--- a/tests/read_config_test.py
+++ b/tests/read_config_test.py
@@ -47,6 +47,8 @@ class TestCheckConfig:
             "inventories": {
                 "dir": REPO_PATH,
                 "files": [INV_NAME],
+                "rel_to_base": False,
+                "base": {"dir": REPO_PATH, "files": [INV_NAME]}
             },
             "output": {
                 "full_run": True,
@@ -72,6 +74,8 @@ class TestCheckConfig:
             "inventories": {
                 "dir": 9,
                 "files": [INV_NAME],
+                "rel_to_base": 1,
+                "base": {"dir": 9, "files": [INV_NAME]}
             },
             "output": {
                 "dir": "results/",


### PR DESCRIPTION
This pull request allows the user to calculate the contrail climate impact of a single flight. It does this by introducing the concept of a "base inventory". If `rel_to_base` is selected TRUE in the config file, then the input emission inventories are calculated on top of the base emission inventories. This is important due to non-linear saturation effects: on a climatological timescale, an aircraft flying alone in the atmosphere will have a larger contrail climate impact than one flying as part of a global air traffic scenario. 

Currently, the inventory and base inventory must align at least in the years defined by the inventory. I will explore whether this can be adapted for further flexibility in the future.

Closes #22