### PR TITLE
Interpolation between base_inv_dict years for contrail climate impact calculations of single flights

### DIFF
--- a/openairclim/calc_cont.py
+++ b/openairclim/calc_cont.py
@@ -64,8 +64,12 @@ def check_cont_input(ds_cont, inv_dict, base_inv_dict):
 
     # check years of inventories
     if base_inv_dict:
-        assert set(inv_dict.keys()).issubset(base_inv_dict.keys()), "inv_dict"\
-        " keys (years) are not a subset of base_inv_dict years (keys)."
+        assert min(base_inv_dict.keys()) <= min(inv_dict.keys()), "The " \
+            f"inv_dict key {min(inv_dict.keys())} is less than the earliest " \
+            f"base_inv_dict key {min(base_inv_dict.keys())}."
+        assert max(base_inv_dict.keys()) >= max(inv_dict.keys()), "The " \
+            f"inv_dict key {max(inv_dict.keys())} is larger than the largest "\
+            f"base_inv_dict key {max(base_inv_dict.keys())}."
 
 
 def calc_cont_grid_areas(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
@@ -117,6 +121,111 @@ def calc_cont_grid_areas(lat: np.ndarray, lon: np.ndarray) -> np.ndarray:
         "calculation is insufficiently accurate."
 
     return areas
+
+
+def interpolate_base_inv_dict(inv_dict, base_inv_dict, intrp_vars):
+    """Create base emission inventories for years in `inv_dict` that do not
+    exist in `base_inv_dict`. 
+
+    Args:
+        inv_dict (dict): Dictionary of emission inventory xarrays,
+            keys are inventory years.
+        base_inv_dict (dict): Dictionary of base emission inventory
+            xarrays, keys are inventory years.
+        intrp_vars (array-like): List of strings of data variables in 
+            base_inv_dict that are to be included in the missing base 
+            inventories, e.g. ["distance", "fuel"].
+
+    Returns:
+        dict: Dictionary of base emission inventory xarrays including any
+            missing years compared to inv_dict, keys are inventory years.
+    """
+
+    # TODO give user the option to select different regridding (currently only nearest)
+    # and interpolation (currently only linear) methods
+
+    # pre-conditions
+
+
+    # if base_inv_dict is empty, then return the empty dictionary
+    # otherwise, continue with the calculations
+    if not base_inv_dict:
+        return {}
+
+    # get years that need to be calculated
+    inv_yrs = list(inv_dict.keys())
+    base_yrs = list(base_inv_dict.keys())
+    intrp_yrs = sorted(set(inv_yrs) - set(base_yrs))
+
+    # initialise output
+    full_base_inv_dict = base_inv_dict.copy()
+
+    # if there are years in inv_dict that do not exist in base_inv_dict
+    if intrp_yrs:
+        # find upper and lower neighbouring base_inv_dict years
+        intrp_yr_idx = np.searchsorted(base_yrs, intrp_yrs)
+        yrs_lb = [base_yrs[idx-1] for idx in intrp_yr_idx]
+        yrs_ub = [base_yrs[idx] for idx in intrp_yr_idx]
+        yrs_regrid = np.unique(yrs_lb + yrs_ub)
+
+        # regrid base inventories to contrail grid
+        regrid_base_inv_dict = {}
+        for yr in yrs_regrid:
+            base_inv = base_inv_dict[yr]
+
+            # find nearest neighbour indices
+            lon_idxs = np.abs(
+                cc_lon_vals[:, np.newaxis] - base_inv.lon.data
+            ).argmin(axis=0)
+            lat_idxs = np.abs(
+                cc_lat_vals[:, np.newaxis] - base_inv.lat.data
+            ).argmin(axis=0)
+            plev_idxs = np.abs(
+                cc_plev_vals[:, np.newaxis] - base_inv.plev.data
+            ).argmin(axis=0)
+
+            # create DataArray for yr
+            regrid_base_inv = {}
+            for intrp_var in intrp_vars:
+                intrp_arr = np.zeros((
+                    len(cc_lon_vals),
+                    len(cc_lat_vals),
+                    len(cc_plev_vals)
+                ))
+                np.add.at(
+                    intrp_arr,
+                    (lon_idxs, lat_idxs, plev_idxs),
+                    base_inv[intrp_var].data.flatten()
+                )
+                regrid_base_inv[intrp_var] = xr.DataArray(
+                    data=intrp_arr,
+                    dims=["lon", "lat", "plev"],
+                    coords={
+                        "lon": cc_lon_vals,
+                        "lat": cc_lat_vals,
+                        "plev": cc_plev_vals,
+                    }
+                )
+
+            # create dataset
+            regrid_base_inv_dict[yr] = xr.Dataset(regrid_base_inv)
+
+        # linearly interpolate base_inv
+        for i, yr in enumerate(intrp_yrs):
+            # linear weighting
+            w = (yr - yrs_lb[i]) / (yrs_ub[i] - yrs_lb[i])
+            ds_i = regrid_base_inv_dict[yrs_lb[i]] * (1 - w) + \
+                regrid_base_inv_dict[yrs_ub[i]] * w
+
+            # reset index to match input inventories
+            ds_i_flat = ds_i.stack(index=["lon", "lat", "plev"])
+            ds_i_flat = ds_i_flat.reset_index("index")
+            full_base_inv_dict[yr] = ds_i_flat
+
+        # sort full_base_inv_dict
+        full_base_inv_dict = dict(sorted(full_base_inv_dict.items()))
+
+    return full_base_inv_dict
 
 
 def calc_cont_weighting(config: dict, val: str) -> np.ndarray:

--- a/openairclim/main.py
+++ b/openairclim/main.py
@@ -199,6 +199,12 @@ def run(file_name):
             # check contrail input
             oac.check_cont_input(ds_cont, inv_dict, base_inv_dict)
 
+            # if necessary, augment base_inv_dict with years in inv_dict not
+            # present in base_inv_dict
+            base_inv_dict = oac.interpolate_base_inv_dict(
+                inv_dict, base_inv_dict, ["distance"]
+            )
+
             # Calculate Contrail Flight Distance Density (CFDD)
             cfdd_dict = oac.calc_cfdd(
                 config, inv_dict, ds_cont

--- a/openairclim/main.py
+++ b/openairclim/main.py
@@ -201,7 +201,7 @@ def run(file_name):
 
             # if necessary, augment base_inv_dict with years in inv_dict not
             # present in base_inv_dict
-            base_inv_dict = oac.interpolate_base_inv_dict(
+            base_inv_dict = oac.interp_base_inv_dict(
                 inv_dict, base_inv_dict, ["distance"]
             )
 


### PR DESCRIPTION
## Description
This pull request adds functionality that allows the years defined in `inv_dict` to vary independently from those defined in `base_inv_dict`. This is helpful if the climate impact of a flight or yearly inventory in for example the year 2024 is desired, but global emission inventories only exist in for example the years 2020 and 2050.

The new function `interp_base_inv_dict` uses a custom nearest neighbour method to regrid the base emission inventories onto the contrail grid, then linearly interpolates between them to get the values at any years in `inv_dict` that are not defined in `base_inv_dict`. It is not possible to include years in `inv_dict` that are outside of the range of years defined by the inventories in `base_inv_dict`. Going forward, I will consider whether this could be possible if one of the scaling functions were to be used on the base emission inventories. 

## Linked issues
Closes #45. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
- [x] Introduced pytest test classes `TestCheckContInput` and `TestInterpBaseInvDict` in `tests/calc_cont_test.py`
- [x] Using randomly generated and DEPA 2050 data

**Test configuration**:
* Operating system: Windows 11

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules