### PR TITLE
Automatic conversion of longitude values to match pre-calculated data

### DIFF
--- a/openairclim/read_netcdf.py
+++ b/openairclim/read_netcdf.py
@@ -93,6 +93,13 @@ def open_inventories(config, base=False):
     # For all evolution_type: "norm" or "scaling" or False
     inv_dict = {}
     for inv_name, inv in inv_inp_dict.items():
+        # Update longitudes to be between 0 and 360 degrees
+        if inv.lon.min() < 0.0:
+            logging.warning(
+                "Longitude values have been automatically updated to be between "
+                "0 and 360 degrees to match pre-calculated data."
+            )
+            inv = inv.assign_coords(lon=inv.lon % 360.0)
         try:
             year = inv.attrs["Inventory_Year"]
             if time_range[0] <= year <= time_range[-1]:


### PR DESCRIPTION
## Description

- Closes #59

The pre-calculated contrail data is defined on a longitude grid from 0 to 360 degrees. This adds a check to ensure that no negative longitude values are present in the input emission inventories (which would indicate that longitude is defined between -180 and +380 degrees), and if so, automatically update them to be between 0 and 360 degrees.

Going forward, I suggest that we move checks on the input emission inventories to a separate function, such that test functions can easily be written. In the current setup, it is not possible to test this solution with a test function directly because the `open_inventories` function loads an `.nc` file.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change

## How has this been tested?
Please describe the software tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Tested using ELK inventory as in the initial bug report #56. Validated against AirClim results.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any changed dependencies have been added or removed correctly
