### PR TITLE
Contrail attribution methodology based on contrail cirrus coverage

### DIFF
--- a/openairclim/calc_cont.py
+++ b/openairclim/calc_cont.py
@@ -880,9 +880,10 @@ def calc_comb_inv_dict(config, inv_dict, base_inv_dict):
     """
 
     # check that inv_dict is a subset of base_inv_dict
-    assert set(inv_dict.keys()).issubset(base_inv_dict.keys()), (
-        "inv_dict keys are not a subset of base_inv_dict keys."
-    )
+    if config["inventories"]["rel_to_base"]:
+        assert set(inv_dict.keys()).issubset(base_inv_dict.keys()), (
+            "inv_dict keys are not a subset of base_inv_dict keys."
+        )
 
     # get aircraft identifiers defined in config
     ac_lst = config["aircraft"]["types"]

--- a/openairclim/interpolate_time.py
+++ b/openairclim/interpolate_time.py
@@ -393,7 +393,8 @@ def calc_inv_quantities(config, inv_dict):
     for spec, sum_arr in inv_sum_dict.items():
         if spec != "fuel":
             # Calculate emission index for spec (array over inventory years)
-            ei_arr = np.divide(sum_arr, fuel_sum_arr)
+            ei_arr = np.divide(sum_arr, fuel_sum_arr, where=fuel_sum_arr != 0.0)
+            ei_arr[fuel_sum_arr == 0.0] = 0.0
             # Get right evolution key from translation table
             evo_key = inv_evo_table[spec]
             # Add array of emission indices for spec to emission index dictionary
@@ -460,7 +461,8 @@ def calc_norm(evo_dict, ei_inv_dict):
     key_table = KEY_TABLE
     evo_fuel = evo_dict["fuel"]
     inv_fuel = ei_inv_dict["fuel"]
-    norm_fuel = np.divide(evo_fuel, inv_fuel)
+    norm_fuel = np.divide(evo_fuel, inv_fuel, where=inv_fuel != 0.0)
+    norm_fuel[inv_fuel == 0.0] = 0.0
     for key, inv_emi_index in ei_inv_dict.items():
         if key == "fuel":
             norm_arr = norm_fuel
@@ -534,7 +536,7 @@ def norm_inv(inv_dict: dict, norm_dict: dict) -> dict:
                 else:
                     data_arr = data_arr * norm_sub_dict[data_key]
             # lon, lat, plev: do NOT multiply
-            elif data_key in ["lon", "lat", "plev"]:
+            elif data_key in ["lon", "lat", "plev", "ac"]:
                 pass
             # species not in norm_inv_dict: multiply with norm_fuel
             else:

--- a/openairclim/write_output.py
+++ b/openairclim/write_output.py
@@ -103,7 +103,7 @@ def write_to_netcdf(config, val_arr_dict, result_type, mode="w"):
                     val_arr,
                     {
                         "long_name": spec + " " + descr["long_name"],
-                        "units": descr["units"][spec],
+                        "units": descr["units"][f"{spec[:4] if spec[:4] == 'cont' else spec}"],
                     },
                 )
             },


### PR DESCRIPTION
## Description
- Closes #69 

This pull request introduces a contrail attribution methodology based on contrail cirrus coverage. With this methodology, it is possible to include multiple different aircraft within the input emission inventories and base emission inventories. This is done with the `ac` data variable in the inventories. In the `config` file, the contrail-relevant parameters are defined per aircraft identifier, e.g. `aircraft.KER.G_cont = 1.80` - this identifier ("KER") must correspond to the identifier in `ac`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change

## How has this been tested?
TBD

**Test configuration**:
* Operating system:
* Other relevant information:

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any changed dependencies have been added or removed correctly
- [ ] main branch: I have updated the CHANGELOG
- [ ] main branch: I have updated the version numbering in `__about__.py` according to the [semantic versioning scheme](https://semver.org/)
