### PR TITLE
Update installation procedure + reduce number of required DEPA inventories for multi_inv demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,21 @@ git clone https://github.com/dlr-pa/oac.git
 
 Make sure that either the [conda](https://docs.conda.io/projects/conda/en/latest/index.html) or [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager is installed on your system.
 
-The source code includes configuration files `environment_xxx.yaml` that enable the installation of a virtual conda environment with all required dependencies. This installation method is suitable for working across platforms. To create an environment from that file, change directory to the root folder of the downloaded source and execute following command:
+The source code includes configuration files `environment_xxx.yaml` that enable the installation of a virtual conda environment with all required dependencies. This installation method is suitable for working across platforms. Change directory to the root folder of the downloaded source and create a conda environment:
 ```
+cd oac
 conda env create -f environment_xxx.yaml
 ```
 
-This installation method allows you to run OpenAirClim locally within the downloaded directory only. In order to be able to run OpenAirClim system-wide, the `PYTHONPATH` variable has to be changed properly that the Python interpreter finds the openairclim package.
+Finally, to install the openairclim package system-wide on your computer, execute one of the following commands:
+```
+pip install .
+```
+or
+```
+pip install -e .
+```
+The `-e` flag treats the openairclim package as an editable install, allowing you to make changes to the source code and see those changes reflected immediately. The latter command is recommended for developers.
 
 After having installed the conda ennvironment and required dependencies, proceed with the steps described in section [Getting started](##getting-started). 
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ git clone https://github.com/dlr-pa/oac.git
 
 Make sure that either the [conda](https://docs.conda.io/projects/conda/en/latest/index.html) or [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager is installed on your system.
 
-The source code includes configuration files `environment_xxx.yaml` that enable the installation of a virtual conda environment with all required dependencies. This installation method is suitable for working across platforms. Change directory to the root folder of the downloaded source and create a conda environment:
+The source code includes configuration files `environment_xxx.yaml` that enable the installation of a virtual conda environment with all required dependencies. This installation method is suitable for working across platforms. Change directory to the root folder of the downloaded source, create a conda environment and activate it:
 ```
 cd oac
 conda env create -f environment_xxx.yaml
+conda activate <env>
 ```
 
-Finally, to install the openairclim package system-wide on your computer, execute one of the following commands:
+Replace `xxx` with the relevant file and `<env>` with the correct name of the installed conda environment, e.g. `oac` or `oac_minimal`.
+Finally, to install the openairclim package system-wide on your computer, execute one of the following commands within the activated conda environment.
+This last installation step isn't necessary if the user has otherwise added the path to the oac source folder to `PYTHONPATH`.
 ```
 pip install .
 ```
@@ -66,7 +69,7 @@ pip install -e .
 ```
 The `-e` flag treats the openairclim package as an editable install, allowing you to make changes to the source code and see those changes reflected immediately. The latter command is recommended for developers.
 
-After having installed the conda ennvironment and required dependencies, proceed with the steps described in section [Getting started](##getting-started). 
+After installing the conda ennvironment and required dependencies, proceed with the steps described in section [Getting started](##getting-started). 
 
 
 ## Getting started

--- a/docs/source/demos/01_norm/norm.rst
+++ b/docs/source/demos/01_norm/norm.rst
@@ -7,6 +7,7 @@ A historic emission scenario is simulated with OpenAirClim.
 
 Imports
 -------
+If the openairclim package cannot be imported, make sure that you have installed the package with pip or added the oac source folder to ``PYTHONPATH``.
 
 .. jupyter-execute::
 

--- a/docs/source/demos/01_norm/norm.rst
+++ b/docs/source/demos/01_norm/norm.rst
@@ -8,9 +8,6 @@ A historic emission scenario is simulated with OpenAirClim.
 Imports
 -------
 
-In some cases, it might be necessary to define `sys.path`, such that the interpreter finds the openairclim package.
-Alternatively, the environment variable, e.g. `PYTHONPATH`, can be configured.
-
 .. jupyter-execute::
 
     import xarray as xr

--- a/docs/source/demos/02_scaling/scaling.rst
+++ b/docs/source/demos/02_scaling/scaling.rst
@@ -7,8 +7,6 @@ The emissions in 2039 are set to be twice as much as in 2019.
 
 Imports
 -------
-In some cases, it might be necessary to define `sys.path`, such that the interpreter finds the openairclim package.
-Alternatively, the environment variable, e.g. `PYTHONPATH`, can be configured.
 
 .. jupyter-execute::
 

--- a/docs/source/demos/02_scaling/scaling.rst
+++ b/docs/source/demos/02_scaling/scaling.rst
@@ -7,6 +7,7 @@ The emissions in 2039 are set to be twice as much as in 2019.
 
 Imports
 -------
+If the openairclim package cannot be imported, make sure that you have installed the package with pip or added the oac source folder to ``PYTHONPATH``.
 
 .. jupyter-execute::
 

--- a/docs/source/demos/03_multi_inv/multi_inv.rst
+++ b/docs/source/demos/03_multi_inv/multi_inv.rst
@@ -7,6 +7,7 @@ OpenAirClim will interpolate between discrete inventory years.
 
 Imports
 -------
+If the openairclim package cannot be imported, make sure that you have installed the package with pip or added the oac source folder to ``PYTHONPATH``.
 
 .. jupyter-execute::
     

--- a/docs/source/demos/03_multi_inv/multi_inv.rst
+++ b/docs/source/demos/03_multi_inv/multi_inv.rst
@@ -7,8 +7,6 @@ OpenAirClim will interpolate between discrete inventory years.
 
 Imports
 -------
-In some cases, it might be necessary to define `sys.path`, such that the interpreter finds the openairclim package.
-Alternatively, the environment variable, e.g. `PYTHONPATH`, can be configured.
 
 .. jupyter-execute::
     
@@ -32,7 +30,7 @@ Emission inventories
 ^^^^^^^^^^^^^^^^^^^^
 
 * Source: DLR research study `DEPA 2050`_
-* Inventory years: 2030, 2035, 2040, 2045, 2050
+* Inventory years: 2030, 2040, 2050
 * Available for download in suitable OpenAirClim format
 
 .. _DEPA 2050: https://elib.dlr.de/142185/
@@ -41,7 +39,7 @@ Emission inventories
 
     %%capture
     # Download inventories from zenodo
-    zenodo_get.zenodo_get(["https://doi.org/10.5281/zenodo.11442322", "-g", "emi_inv_20[3-5]?.nc", "-o", "source/demos/input/"])
+    zenodo_get.zenodo_get(["https://doi.org/10.5281/zenodo.11442322", "-g", "emi_inv_20[3-5]0.nc", "-o", "source/demos/input/"])
 
 
 Simulation run

--- a/docs/source/demos/03_multi_inv/multi_inv.toml
+++ b/docs/source/demos/03_multi_inv/multi_inv.toml
@@ -17,9 +17,7 @@ out = ["CO2", "H2O", "cont"]
 dir = "source/demos/input/"
 files = [
     "emi_inv_2030.nc",
-    "emi_inv_2035.nc",
     "emi_inv_2040.nc",
-    "emi_inv_2045.nc",
     "emi_inv_2050.nc"
 ]
 # base emission inventories, only considered if rel_to_base = true

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,15 +28,17 @@ Please check with your IT department (if applicable).
 The source code includes configuration files ``environment_xxx.yaml`` that enable the installation of a conda environment with all required dependencies.
 This installation method is suitable for working across platforms.
 Use the ``dev`` file if you are planning on making changes to the code or contributing to the development of OpenAirClim, otherwise use ``minimal``.
-Change directory to the root folder of the downloaded source and create a conda environment:
+Change directory to the root folder of the downloaded source and create a conda environment and activate it:
 
 .. code-block:: bash
 
     cd oac
     conda env create -f environment_xxx.yaml
+    conda activate <env>
 
-Of course replacing ``xxx`` with the relevant file.
-Finally, to install the openairclim package system-wide on your computer, execute one of the following commands:
+Replace ``xxx`` with the relevant file and ``<env>`` with the correct name of the installed conda environment, e.g ``oac`` or ``oac_minimal``.
+Finally, to install the openairclim package system-wide on your computer, execute one of the following commands within the activated conda environment.
+This last installation step isn't necessary if the user has otherwise added the path to the oac source folder to ``PYTHONPATH``.
 
 .. code-block:: bash
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,21 +28,28 @@ Please check with your IT department (if applicable).
 The source code includes configuration files ``environment_xxx.yaml`` that enable the installation of a conda environment with all required dependencies.
 This installation method is suitable for working across platforms.
 Use the ``dev`` file if you are planning on making changes to the code or contributing to the development of OpenAirClim, otherwise use ``minimal``.
-To create an environment from that file, change directory to the root folder of the downloaded source and execute the following command:
+Change directory to the root folder of the downloaded source and create a conda environment:
 
 .. code-block:: bash
 
+    cd oac
     conda env create -f environment_xxx.yaml
 
 Of course replacing ``xxx`` with the relevant file.
-This installation method allows you to run OpenAirClim locally within the downloaded directory only.
-We are working on creating an official python package, so that OpenAirClim is available system-wide via the conda environment.
-For now, in order to be able to run OpenAirClim system-wide, the ``PYTHONPATH`` variable has to be configured, or the path added manually using:
+Finally, to install the openairclim package system-wide on your computer, execute one of the following commands:
 
-.. code-block:: python
+.. code-block:: bash
 
-    import sys
-    sys.path.append("/link/to/main/oac/folder")
+    pip install .
+
+or
+
+.. code-block:: bash
+
+    pip install -e .
+
+The ``-e`` flag treats the openairclim package as an editable install, allowing you to make changes to the source code and see those changes reflected immediately.
+The latter command is recommended for developers.
 
 After installing the conda environment and required dependencies, proceed with the steps described in :doc:`quickstart`.
 


### PR DESCRIPTION
Updated installation procedure using a pip command at the end to install openairclim system-wide. Updated multi_inv.rst with only three inventories instead of five to reduce deployment time.

## Before you get started
- [ ] 🙋‍♀️ Create an issue to discuss what you are going to do!

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change

## How has this been tested?
The new installation procedure was tested locally. A jupyter notebook in a different directory than the source code was created, and `import openairclim as oac` was successfully executed.
The updated multi_inv demo was tested locally via `make html` and the html output was checked.
Existing unit tests run successfully.

**Test configuration**:
* Operating system: Microsoft Windows 11, 64-bit

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any changed dependencies have been added or removed correctly
- [ ] main branch: I have updated the CHANGELOG
- [ ] main branch: I have updated the version numbering in `__about__.py` according to the [semantic versioning scheme](https://semver.org/)
