### PR TITLE
Feature/scaling multi species

### DIFF
--- a/openairclim/interpolate_time.py
+++ b/openairclim/interpolate_time.py
@@ -7,6 +7,7 @@ import xarray as xr
 from scipy.interpolate import RegularGridInterpolator
 from openairclim.read_netcdf import get_evolution_type
 from openairclim.utils import tg_to_kg
+import warnings
 
 # from scipy.interpolate import interp1d
 

--- a/tests/interpolate_time_test.py
+++ b/tests/interpolate_time_test.py
@@ -5,6 +5,7 @@ Provides tests for module interpolate_time
 import numpy as np
 import pytest
 import openairclim as oac
+import xarray as xr
 from utils.create_test_data import create_test_inv
 
 
@@ -301,27 +302,43 @@ class TestScaleInv:
 class TestApplyScaling:
     """Tests for apply_scaling function"""
 
-    def test_basic_scaling(self, inv_dict):
+    def test_basic_scaling(self, inv_dict, monkeypatch):
         """Test that apply_scaling correctly multiplies by scaling factors"""
+        # --- Create minimal scaling dataset ---
 
-        # --- Config ---
+        scaling_time = np.arange(2020, 2051, 1)
+        species_arr  = ["fuel", "CO2", "H2O", "NOx", "distance"]
+        scaling_arr = np.vstack([
+            np.linspace(1.0, 2.0, len(scaling_time)),   # fuel
+            np.linspace(1.0, 1.75, len(scaling_time)),  # CO2
+            np.linspace(1.0, 1.5, len(scaling_time)),   # H2O
+            np.linspace(1.0, 0.8, len(scaling_time)),   # NOx
+            np.linspace(1.0, 1.2, len(scaling_time)),   # distance
+        ]).T  # shape (time, species)
+
+        evolution = xr.Dataset(
+            data_vars=dict(scaling=(["time", "species"], scaling_arr)),
+            coords=dict(time=scaling_time, species=species_arr),
+        )
+        # --- Mock config ---
         config = {
             "time": {
-                "dir": "../oac/example/input/",
-                "file": "time_scaling_example.nc",
-                "range": [2020, 2051, 1],
+                "dir": "",      #placeholders
+                "file": "",
+                "range": [2020, 2051, 1],  
+                "xr_object": evolution,    
             }
         }
 
-        # --- Load scaling file to get species order ---
-        evolution = xr.load_dataset(config["time"]["dir"] + config["time"]["file"])
-        species_order = evolution.species.values.tolist()
-        scaling = evolution.scaling.values
-        scaling_years = evolution.time.values
+        monkeypatch.setattr(oac.xr, "load_dataset", lambda *_: evolution)
 
         # --- Prepare dummy val_dict ---
         years = np.array(list(inv_dict.keys()))
-        val_dict = {spec: np.ones(len(years)) * (i + 1) for i, spec in enumerate(species_order)}
+        val_dict = {
+            spec: np.ones(len(years)) * (i + 1)
+            for i, spec in enumerate(species_arr)
+        }
+
 
         # --- Run apply_scaling ---
         time_range, out_dict = oac.apply_scaling(config, val_dict, inv_dict, inventories_adjusted=False)
@@ -333,6 +350,6 @@ class TestApplyScaling:
         assert all(out_dict[spec].shape == time_range.shape for spec in val_dict)
 
         # --- Check scaling applied correctly ---
-        for idx, spec in enumerate(species_order):
-            expected = np.interp(time_range, scaling_years, scaling[:, idx]) * val_dict[spec][0]
+        for idx, spec in enumerate(species_arr):
+            expected = np.interp(time_range, scaling_time, scaling_arr[:, idx]) * val_dict[spec][0]
             np.testing.assert_allclose(out_dict[spec], expected, rtol=1e-12)

--- a/utils/create_time_evolution.py
+++ b/utils/create_time_evolution.py
@@ -10,7 +10,7 @@ OUT_PATH = "../example/input/"
 
 # SCALING CONSTANTS
 SCALING_TIME = np.arange(1990, 2200, 1)
-SPECIES = ["fuel", "CO2", "H2O", "NOx", "distance"]
+SPECIES_ARR = ["fuel", "CO2", "H2O", "NOx", "distance"]
 SCALING_DATA = np.vstack([
     np.linspace(1.0, 2.0, len(SCALING_TIME)),             # fuel: +100% growth
     np.linspace(1.0, 1.75, len(SCALING_TIME)),            # CO2: +75% growth
@@ -80,7 +80,7 @@ DIS_PER_FUEL_ARR = 0.3 * np.ones(len(NORM_TIME), dtype="float32")
 # TIME SCALING
 
 
-def plot_time_scaling(scaling_time: np.ndarray, scaling: np.ndarray, species: list):
+def plot_time_scaling(scaling_time: np.ndarray, scaling_arr: np.ndarray, species_arr: list):
     """
     Plots the time scaling factors.
 
@@ -93,9 +93,9 @@ def plot_time_scaling(scaling_time: np.ndarray, scaling: np.ndarray, species: li
         None
 
     """
-    plt.figure(figsize=(8, 4))
-    for i, specie in enumerate(species):
-        plt.plot(scaling_time, scaling[i], label=specie)
+    plt.figure(num="Scaling factors over time by species", figsize=(8, 4))
+    for i, species in enumerate(species_arr):
+        plt.plot(scaling_time, scaling_arr[i], label=species)
     plt.xlabel("Year")
     plt.ylabel("Scaling factor")
     plt.title("Scaling factors over time by species")
@@ -106,7 +106,7 @@ def plot_time_scaling(scaling_time: np.ndarray, scaling: np.ndarray, species: li
 
 
 def create_time_scaling_xr(
-    scaling_time: np.ndarray, scaling: np.ndarray, species: list
+    scaling_time: np.ndarray, scaling_arr: np.ndarray, species_arr: list
 ) -> xr.Dataset:
     """
     Create an xarray dataset containing time scaling factors.
@@ -121,8 +121,8 @@ def create_time_scaling_xr(
 
     """
     evolution = xr.Dataset(
-        data_vars=dict(scaling=(["time", "species"], scaling.T)),
-        coords=dict(time=scaling_time, species=species),
+        data_vars=dict(scaling=(["time", "species"], scaling_arr.T)),
+        coords=dict(time=scaling_time, species=species_arr),
     )
     evolution.time.attrs = {"units": "years"}
     evolution.species.attrs = {"description": "species names"}
@@ -231,9 +231,9 @@ def convert_xr_to_nc(ds: xr.Dataset, file_name: str, out_path: str = OUT_PATH):
 
 
 if __name__ == "__main__":
-    scaling_ds = create_time_scaling_xr(SCALING_TIME, SCALING_DATA, SPECIES)
+    scaling_ds = create_time_scaling_xr(SCALING_TIME, SCALING_DATA, SPECIES_ARR)
     convert_xr_to_nc(scaling_ds, "time_scaling_example")
-    plot_time_scaling(SCALING_TIME, SCALING_DATA, SPECIES)
+    plot_time_scaling(SCALING_TIME, SCALING_DATA, SPECIES_ARR)
     norm_ds = create_time_normalization_xr(
         NORM_TIME, FUEL_ARR, EI_CO2_ARR, EI_H2O_ARR, DIS_PER_FUEL_ARR
     )


### PR DESCRIPTION
## Description
- Closes Issue #93 (closed)
- Closes Issue #34 

It extends the time interpolation and scaling capabilities of OpenAirClim to support individual scaling factors per species in the emission inventory.
This allows, for instance, different scaling factors to be applied when using multiple fuel types or accounting for species-specific emission changes.

This improvement addresses the TODO note previously present in apply_scaling:
> "TODO: implement scaling for individual species"

**Main changes**

- interpolate_time.py
               Updated scale_inv and apply_scaling to handle multiple emission scaling factors (one per species).
- create_time_evolution.py
              Modified to generate a coherent example including species-dependent scaling.
- interpolate_time_test.py
              Updated unit tests to reflect the new behavior.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
- Updated the existing test suite in interpolate_time_test.py to validate per-species scaling.
- Verified functionality manually using a sample NETCDF4 file with the following structure:
`<class 'netCDF4.Dataset'>
root group (NETCDF4 data model, file format HDF5):
    Title: Time scaling example
    Convention: CF-XXX
    Type: scaling
    dimensions(sizes): time(210), species(5)
    variables(dimensions): float32 scaling(time, species), int64 time(time), <class 'str'> species(species)
    groups: `

Example
`print(file2read.variables['species'][:])  # ['fuel' 'CO2' 'H2O' 'NOx' 'distance']`

To reproduce:

1. Create a NetCDF file with the structure above.
2. Run OpenAirClim using the same .toml configuration as for the standard scaling example.

**Test configuration**:
* Operating system: win32
* Environment: environment_dev.yaml

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any changed dependencies have been added or removed correctly
- [ ] main branch: I have updated the CHANGELOG
- [ ] main branch: I have updated the version numbering in `__about__.py` according to the [semantic versioning scheme](https://semver.org/)
