### PR TITLE
Fix lambda CO2

### DIFF
--- a/docs/source/demos/01_norm/historic.toml
+++ b/docs/source/demos/01_norm/historic.toml
@@ -79,9 +79,9 @@ cont.resp.file = "resp_cont_lf.nc"
 [temperature]
 # valid methods: "Boucher&Reddy"
 method = "Boucher&Reddy"
-# Climate sensitivity parameter, Ponater et al. 2006, Table 1
-# https://doi.org/10.1016/j.atmosenv.2006.06.036
-CO2.lambda = 0.73
+# Climate sensitivity parameter, defaults to 1.06 K/(W/m2) from 
+# Boucher & Reddy (2008): https://doi.org/10.1016/j.enpol.2007.08.039
+CO2.lambda = 1.06
 # Efficacies, Ponater et al. 2006, Table 1
 H2O.efficacy = 1.14
 O3.efficacy = 1.37

--- a/docs/source/demos/02_scaling/scaling.toml
+++ b/docs/source/demos/02_scaling/scaling.toml
@@ -79,9 +79,9 @@ cont.resp.file = "resp_cont_lf.nc"
 [temperature]
 # valid methods: "Boucher&Reddy"
 method = "Boucher&Reddy"
-# Climate sensitivity parameter, Ponater et al. 2006, Table 1
-# https://doi.org/10.1016/j.atmosenv.2006.06.036
-CO2.lambda = 0.73
+# Climate sensitivity parameter, defaults to 1.06 K/(W/m2) from 
+# Boucher & Reddy (2008): https://doi.org/10.1016/j.enpol.2007.08.039
+CO2.lambda = 1.06
 # Efficacies, Ponater et al. 2006, Table 1
 H2O.efficacy = 1.14
 O3.efficacy = 1.37

--- a/docs/source/demos/03_multi_inv/multi_inv.toml
+++ b/docs/source/demos/03_multi_inv/multi_inv.toml
@@ -82,9 +82,9 @@ cont.resp.file = "resp_cont_lf.nc"
 [temperature]
 # valid methods: "Boucher&Reddy"
 method = "Boucher&Reddy"
-# Climate sensitivity parameter, Ponater et al. 2006, Table 1
-# https://doi.org/10.1016/j.atmosenv.2006.06.036
-CO2.lambda = 0.73
+# Climate sensitivity parameter, defaults to 1.06 K/(W/m2) from 
+# Boucher & Reddy (2008): https://doi.org/10.1016/j.enpol.2007.08.039
+CO2.lambda = 1.06
 # Efficacies, Ponater et al. 2006, Table 1
 H2O.efficacy = 1.14
 O3.efficacy = 1.37

--- a/example/example.toml
+++ b/example/example.toml
@@ -101,9 +101,9 @@ cont.resp.file = "resp_cont_lf.nc"
 [temperature]
 # valid methods: "Boucher&Reddy"
 method = "Boucher&Reddy"
-# Climate sensitivity parameter, Ponater et al. 2006, Table 1
-# NOTE: Currently has no effect.
-CO2.lambda = 0.73
+# Climate sensitivity parameter, defaults to 1.06 K/(W/m2) from 
+# Boucher & Reddy (2008): https://doi.org/10.1016/j.enpol.2007.08.039
+CO2.lambda = 1.06
 # Efficacies from Table 3.1 of report EC-CLIMA/2024/NP/0014
 # https://climate.ec.europa.eu/document/download/735ae93d-d49d-46e0-b95b-48c36230ad57_en
 H2O.efficacy = 1.0    # expected range: [0.7, 1.3]

--- a/openairclim/core/calc_dt.py
+++ b/openairclim/core/calc_dt.py
@@ -56,12 +56,17 @@ def calc_dtemp_br2008(
         time_config[0], time_config[1], time_config[2], dtype=int
     )
     delta_t = time_config[2]
-    lambda_co2 = config["temperature"]["CO2"]["lambda"]
+
+    # calculate lambda for the species
+    lambda_co2_input = config["temperature"]["CO2"]["lambda"]
+    lambda_co2_br2008 = 1.06  # default value (sum of c_i)
     if spec == "CO2":
         efficacy = 1.0
     else:
         efficacy = config["temperature"][spec]["efficacy"]
-    lambda_spec = efficacy * lambda_co2
+    lambda_spec = efficacy * lambda_co2_input
+
+    # for loop over time
     dtemp_arr = np.zeros(len(time_range))
     i = 0
     for year in time_range:
@@ -70,7 +75,7 @@ def calc_dtemp_br2008(
         for year_dash in time_range[: (i + 1)]:
             dtemp = (
                 dtemp
-                + (lambda_spec / lambda_co2)
+                + (lambda_spec / lambda_co2_br2008)
                 * rf_arr[j]
                 * calc_delta_temp_br2008((year - year_dash), C_ARR, D_ARR)
                 * delta_t

--- a/openairclim/core/config_model.py
+++ b/openairclim/core/config_model.py
@@ -281,10 +281,9 @@ class _CO2TemperatureConfig(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     lambda_: float = Field(
         alias="lambda",
-        default=0.73,
-        description="Default climate sensitivity parameter from Table 1 of "
-        "[Ponater et al. (2006)](https://doi.org/10.1016/j.atmosenv.2006.06.036). "
-        "NOTE: Currently has no effect."
+        default=1.06,
+        description="Climate sensitivity parameter, defaults to 1.06 K/(W/m2) "
+        "[(Boucher & Reddy, 2008)](https://doi.org/10.1016/j.enpol.2007.08.039)."
     )
 
 


### PR DESCRIPTION
## Description
- Closes #129

This pull request updates the default $\lambda_{CO_2}$ to 1.06, matching Boucher & Reddy (2008), which is used to calculate the temperature change. It uses the $\lambda_{CO_2}$ provided in the config to linearly scale the dT, allowing other $\lambda_{CO_2}$ values to be simulated by OpenAirClim.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change

## How has this been tested?
- [x] End-to-end CO2 doubling experiment with different $\lambda_{CO_2}$ values

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any changed dependencies have been added or removed correctly
- [ ] main branch: I have updated the CHANGELOG
- [ ] main branch: I have updated the version numbering in `__about__.py` according to the [semantic versioning scheme](https://semver.org/)
