### PR TITLE
Remove separate plot windows

### DIFF
--- a/openairclim/core/main.py
+++ b/openairclim/core/main.py
@@ -352,7 +352,7 @@ def run(file_name):
     run_plots = config["output"]["run_plots"]
     if run_plots:
         # Plot vertical profiles of inventories
-        plot.plot_inventory_vertical_profiles(inv_dict)
+        plot.plot_inventory_vertical_profiles(inv_dict, output_dir)
 
         # Plot results
         output_name = config["output"]["name"]

--- a/openairclim/core/plot.py
+++ b/openairclim/core/plot.py
@@ -11,12 +11,13 @@ import matplotlib.pyplot as plt
 BINS = 50
 
 
-def plot_inventory_vertical_profiles(inv_dict):
+def plot_inventory_vertical_profiles(inv_dict, output_dir):
     """Plots vertical emission profiles of dictionary of inventories
 
     Args:
         inv_dict (dict): Dictionary of xarray Datasets,
             keys are years of emission inventories
+        output_dir (str or Path): Directory to save the plot to
     """
     n_inv = len(inv_dict.keys())
     fig, axs = plt.subplots(ncols=n_inv, sharex=True, sharey=True, num="Inventories")
@@ -51,7 +52,7 @@ def plot_inventory_vertical_profiles(inv_dict):
     fig.supxlabel("fuel (kg)")
     fig.supylabel("plev (hPa)")
     plt.gca().invert_yaxis()
-    plt.show()
+    fig.savefig(Path(output_dir) / "inventory_vertical_profiles.png")
 
 
 def plot_results(config, result_dic, ac="TOTAL", **kwargs):
@@ -122,7 +123,6 @@ def plot_results(config, result_dic, ac="TOTAL", **kwargs):
                 axis.grid(True)
                 plt_i = plt_i + 1
             fig.savefig(Path(output_dir) / f"{result_name}_{spec}.png")
-        plt.show()
 
 
 def plot_concentrations(config, spec, conc_dict):
@@ -142,4 +142,3 @@ def plot_concentrations(config, spec, conc_dict):
     fig = plot_object.fig
     fig.canvas.manager.set_window_title(spec)
     fig.savefig(Path(output_dir) / f"conc_{spec}.png")
-    plt.show()

--- a/openairclim/utils/create_artificial_inventories.py
+++ b/openairclim/utils/create_artificial_inventories.py
@@ -302,13 +302,15 @@ def convert_xr_dict_to_nc(
         inv.to_netcdf(out_file)
 
 
-def plot_sample_emission_inventory(rnd_inv_dict):
+def plot_sample_emission_inventory(rnd_inv_dict, out_path: str = OUT_PATH):
     """
     Plots a sample emission inventory from the provided dictionary of xarray datasets.
 
     Args:
         rnd_inv_dict (dict): Dictionary of xarray datasets, where the keys are the
             inventory years and the values are the datasets for that year.
+        out_path (str, optional): The path to the output directory.
+            Defaults to OUT_PATH.
 
     Returns:
         None: None
@@ -317,7 +319,7 @@ def plot_sample_emission_inventory(rnd_inv_dict):
     rnd_inv = next(iter(rnd_inv_dict.values()))
     rnd_inv.plot.scatter(x="lon", y="lat", hue="fuel")
     # plt.gca().invert_yaxis()
-    plt.show()
+    plt.gcf().savefig(os.path.join(out_path, "sample_emission_inventory.png"))
 
 
 def main():
@@ -335,15 +337,16 @@ def main():
     )
     parser.add_argument(
         "-p", "--plot", action="store_true", default=False,
-        help="Show plots of the generated inventories (default: False).",
+        help="Save plots of the generated inventories to output-dir "
+             "(default: False).",
     )
     args = parser.parse_args()
 
     art_inv_dict = ArtificialInventoryDict(year_arr=YEAR_ARR).create()
     convert_xr_dict_to_nc(art_inv_dict, out_path=args.output_dir)
     if args.plot:
-        plot_inventory_vertical_profiles(art_inv_dict)
-        plot_sample_emission_inventory(art_inv_dict)
+        plot_inventory_vertical_profiles(art_inv_dict, args.output_dir)
+        plot_sample_emission_inventory(art_inv_dict, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/openairclim/utils/create_time_evolution.py
+++ b/openairclim/utils/create_time_evolution.py
@@ -74,23 +74,27 @@ DIS_PER_FUEL_ARR = 0.3 * np.ones(len(NORM_TIME), dtype="float32")
 # TIME SCALING
 
 
-def plot_time_scaling(scaling_time: np.ndarray, scaling_arr: np.ndarray):
+def plot_time_scaling(
+    scaling_time: np.ndarray, scaling_arr: np.ndarray, out_path: str = OUT_PATH
+):
     """
     Plots the time scaling factors.
 
     Args:
         scaling_time (np.ndarray): The time values for the scaling factors.
         scaling_arr (np.ndarray): The scaling factors to plot.
+        out_path (str, optional): The path to the output directory.
+            Defaults to OUT_PATH.
 
     Returns:
         None
 
     """
-    _fig, ax = plt.subplots()
+    fig, ax = plt.subplots()
     ax.plot(scaling_time, scaling_arr)
     ax.set_xlabel("year")
     ax.set_ylabel("scaling factor")
-    plt.show()
+    fig.savefig(os.path.join(out_path, "time_scaling.png"))
 
 
 def create_time_scaling_xr(
@@ -175,25 +179,27 @@ def create_time_normalization_xr(
     return evolution
 
 
-def plot_time_norm(evolution):
+def plot_time_norm(evolution, out_path: str = OUT_PATH):
     """Plot normalized values
 
     Args:
         evolution (xr.Dataset): The xarray Dataset containing the normalization factors.
+        out_path (str, optional): The path to the output directory.
+            Defaults to OUT_PATH.
 
     Returns:
         None
     """
     co2_emi_arr = np.multiply(evolution.fuel.values, evolution.EI_CO2.values)
 
-    _fig, axs = plt.subplots(nrows=2)
+    fig, axs = plt.subplots(nrows=2)
     axs[0].grid(True)
     axs[1].grid(True)
     evolution.fuel.plot.line("-o", ax=axs[0])
     axs[1].plot(evolution.time.values, co2_emi_arr, "-o")
     axs[1].set_xlabel("time [years]")
     axs[1].set_ylabel("CO2 emissions [Tg]")
-    plt.show()
+    fig.savefig(os.path.join(out_path, "time_norm.png"))
 
 
 # WRITE OUTPUT netCDF
@@ -231,20 +237,21 @@ def main():
     )
     parser.add_argument(
         "-p", "--plot", action="store_true", default=False,
-        help="Show plots of the generated time evolution files (default: False).",
+        help="Save plots of the generated time evolution files to output-dir "
+             "(default: False).",
     )
     args = parser.parse_args()
 
     scaling_ds = create_time_scaling_xr(SCALING_TIME, SCALING_ARR)
     convert_xr_to_nc(scaling_ds, "time_scaling_example", out_path=args.output_dir)
     if args.plot:
-        plot_time_scaling(SCALING_TIME, SCALING_ARR)
+        plot_time_scaling(SCALING_TIME, SCALING_ARR, out_path=args.output_dir)
     norm_ds = create_time_normalization_xr(
         NORM_TIME, FUEL_ARR, EI_CO2_ARR, EI_H2O_ARR, DIS_PER_FUEL_ARR
     )
     convert_xr_to_nc(norm_ds, "time_norm_example", out_path=args.output_dir)
     if args.plot:
-        plot_time_norm(norm_ds)
+        plot_time_norm(norm_ds, out_path=args.output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
- Associated with #124 
- To be merged after #142 (was branched off `feature/uv`)

This PR removes all `plt.show()` calls such that `matplotlib-base` is sufficient as a dependency for conda-forge (rather than `matplotlib`, which requires a number of heavier packages to also be installed).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The `example/example.toml` config file runs with a clean installation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any changed dependencies have been added or removed correctly
